### PR TITLE
Fix: a `:routine/fn` should receive `w` as first argument, otherwise …

### DIFF
--- a/routine/src/clj/parts/routine/core.clj
+++ b/routine/src/clj/parts/routine/core.clj
@@ -34,7 +34,7 @@
   [w]
   (.incrementAndGet @active-routines-count)
   (try
-    ((:routine/fn (:routine w)))
+    ((:routine/fn (:routine w)) w)
     (catch Throwable e
       ;; If `scheduleWithFixedDelay` encounters an exception it suppresses
       ;; subsequent executions. Therefore any errors are catched and logged here


### PR DESCRIPTION
…it has no access to things like the `:datomic/con`, etc.