### PR TITLE
Forward top-level error from command response

### DIFF
--- a/replicant/src/cljs/parts/replicant/command_query.cljs
+++ b/replicant/src/cljs/parts/replicant/command_query.cljs
@@ -50,9 +50,13 @@
                             on-error)
                    (event-handler {:command command
                                    :response res
-                                   :error (get-in res
-                                                  [:result
-                                                   :error])}
+                                   ;; A command-fn returns the error under [:result :error].
+                                   ;; When the command-fn throws, the server returns
+                                   ;; {:error :command-fn-failed} at the top level.
+                                   :error (or (get-in res
+                                                    [:result
+                                                     :error])
+                                              (:error res))}
                                   on-error))))
         (.catch (fn [error]
                   (js/console.error "issue-command error:" error)


### PR DESCRIPTION
## Summary
- When a command handler throws, the server returns `{:error :command-fn-failed}` at the top level
- The client only checked `[:result :error]` for the error message, so `nil` was forwarded to `on-error` handlers
- Now falls back to the top-level `:error` key when `[:result :error]` is absent

## Test plan
- [ ] Trigger a command that throws an exception on the server — error message should now be forwarded to the UI
- [ ] Normal command errors (`{:success? false :result {:error "..."}}`) should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)