### PR TITLE
Add UUIDs to commands before sending

### DIFF
--- a/replicant/src/cljs/parts/replicant/command_query.cljs
+++ b/replicant/src/cljs/parts/replicant/command_query.cljs
@@ -23,15 +23,22 @@
                          query
                          {:error (.-message error)}))))))
 
+(defn ensure-command-uuid
+  [command]
+  (cond-> command
+    (not (:command/uuid command))
+    (assoc :command/uuid (random-uuid))))
+
 (defn issue-command
   [{:keys [ui/store action] :as w}]
   (let [[_ command & [{:keys [on-success on-error]}]] action
-        event-handler (:ui/event-handler w)]
+        event-handler (:ui/event-handler w)
+        command* (ensure-command-uuid command)]
     (swap! store command/issue-command (js/Date.) command)
     (-> (js/fetch (or (:ui/command-endpoint w)
                       "/command")
                   #js {:method "POST"
-                       :body (transit/transit-encode command)})
+                       :body (transit/transit-encode command*)})
         (.then #(.text %))
         (.then transit/transit-decode)
         (.then (fn [res]

--- a/replicant/src/cljs/parts/replicant/command_query.cljs
+++ b/replicant/src/cljs/parts/replicant/command_query.cljs
@@ -41,7 +41,8 @@
     (-> (js/fetch (or (:ui/command-endpoint w)
                       "/command")
                   #js {:method "POST"
-                       :body (transit/transit-encode command*)})
+                       :body (transit/transit-encode command*
+                                                     write-opts)})
         (.then #(.text %))
         (.then (fn [text]
                  (transit/transit-decode text


### PR DESCRIPTION
## Summary
- add `ensure-command-uuid` for Replicant command actions
- send commands with a client-generated `:command/uuid` when missing
- keep the UI command log keyed by the original command map so existing `issued?` checks continue to work

## Testing
- `git diff --check`